### PR TITLE
Static link and fix custom PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 BIN = clightning-dumpkeys
 PREFIX ?= /usr/local
 
-LDFLAGS = -lsecp256k1
-CFLAGS = $(DEFS) -DHAVE_LITTLE_ENDIAN -O2 -g -I src -Wall -Werror -Wextra -std=c99
+LDFLAGS = -l:libsecp256k1.a -L${PREFIX}/lib
+CFLAGS = $(DEFS) -DHAVE_LITTLE_ENDIAN -O2 -g -I ${PREFIX}/include -Wall -Werror -Wextra -std=c99
 
 OBJS  = sha256.o
 OBJS += sha512.o


### PR DESCRIPTION
This lets you do something like so:

```sh
mkdir legacy
mkdir src
git clone https://github.com/bitcoin-core/secp256k1.git
cd secp256k1
git checkout 3db0560606acb285cc7ef11662ce166ed67e9015
./autogen
./configure --prefix=/home/lightning/legacy
make
make install
cd ..

git clone https://github.com/jb55/clightning-dumpkeys
PREFIX=/home/lightning/legacy make
```

This avoids polluting your normal libraries with an arbitrary (ancient) version of libsecp. As well as lets you do this with root permissions (no /usr/local)

I'm not a build-system guru though.